### PR TITLE
Add support for creating / deleting .cache folder on plugin activation / deactivation

### DIFF
--- a/bladerunner.php
+++ b/bladerunner.php
@@ -22,3 +22,6 @@ require_once __DIR__.'/src/blade.php';
 
 new Bladerunner\Init();
 new Bladerunner\Template();
+
+register_activation_hook( __FILE__, '\Bladerunner\Init::create_cache_directory');
+register_deactivation_hook( __FILE__, '\Bladerunner\Init::delete_cache_directory');

--- a/bladerunner.php
+++ b/bladerunner.php
@@ -23,5 +23,5 @@ require_once __DIR__.'/src/blade.php';
 new Bladerunner\Init();
 new Bladerunner\Template();
 
-register_activation_hook( __FILE__, '\Bladerunner\Init::create_cache_directory');
-register_deactivation_hook( __FILE__, '\Bladerunner\Init::delete_cache_directory');
+register_activation_hook(__FILE__, '\Bladerunner\Init::create_cache_directory');
+register_deactivation_hook(__FILE__, '\Bladerunner\Init::delete_cache_directory');

--- a/src/init.php
+++ b/src/init.php
@@ -61,6 +61,7 @@ class init
         foreach ($files as $file) {
             (is_dir("$dir/$file") && !is_link($dir)) ? self::delete_directory("$dir/$file") : unlink("$dir/$file");
         }
+        
         return rmdir($dir);
     }
 

--- a/src/init.php
+++ b/src/init.php
@@ -52,6 +52,7 @@ class init
      * http://php.net/manual/en/function.rmdir.php#114183 - source.
      *
      * @param $dir
+     *
      * @return bool
      */
     public static function delete_directory($dir)

--- a/src/init.php
+++ b/src/init.php
@@ -32,7 +32,7 @@ class init
     }
 
     /**
-     * Creates the public cache folder
+     * Creates the public cache folder.
      */
     public static function create_cache_directory()
     {
@@ -40,7 +40,7 @@ class init
     }
 
     /**
-     * Deletes the public cache folder
+     * Deletes the public cache folder.
      */
     public static function delete_cache_directory()
     {
@@ -49,13 +49,14 @@ class init
 
     /**
      * Helper function
-     * http://php.net/manual/en/function.rmdir.php#114183
+     * http://php.net/manual/en/function.rmdir.php#114183 - source.
      *
      * @param $dir
      * @return bool
      */
-    public static function delete_directory($dir) {
-        $files = array_diff(scandir($dir), array('.', '..'));
+    public static function delete_directory($dir)
+    {
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             (is_dir("$dir/$file") && !is_link($dir)) ? self::delete_directory("$dir/$file") : unlink("$dir/$file");
         }

--- a/src/init.php
+++ b/src/init.php
@@ -32,6 +32,37 @@ class init
     }
 
     /**
+     * Creates the public cache folder
+     */
+    public static function create_cache_directory()
+    {
+        wp_mkdir_p(Template::cache());
+    }
+
+    /**
+     * Deletes the public cache folder
+     */
+    public static function delete_cache_directory()
+    {
+        self::delete_directory(Template::cache());
+    }
+
+    /**
+     * Helper function
+     * http://php.net/manual/en/function.rmdir.php#114183
+     *
+     * @param $dir
+     * @return bool
+     */
+    public static function delete_directory($dir) {
+        $files = array_diff(scandir($dir), array('.', '..'));
+        foreach ($files as $file) {
+            (is_dir("$dir/$file") && !is_link($dir)) ? self::delete_directory("$dir/$file") : unlink("$dir/$file");
+        }
+        return rmdir($dir);
+    }
+
+    /**
      * Echo admin notice inside wp-admin if cache folder doesnt exist.
      *
      * @return void


### PR DESCRIPTION
Unfortunately no great way in core to recursively delete a folder (Unless you want to initialize `WP_Filesystem`, which is a hassle) but this should be simple enough. :)
