### PR TITLE
Error out on missing cache folder

### DIFF
--- a/src/template.php
+++ b/src/template.php
@@ -38,6 +38,10 @@ class template
             return $this->path;
         }
 
+        if (!$template) {
+            return $template;
+        }
+
         $template = apply_filters('bladerunner/get_post_template', $template);
 
         $views = get_stylesheet_directory();

--- a/src/template.php
+++ b/src/template.php
@@ -38,17 +38,14 @@ class template
             return $this->path;
         }
 
-        if (!$template) {
-            return $template;
-        }
-
         $template = apply_filters('bladerunner/get_post_template', $template);
 
         $views = get_stylesheet_directory();
 
         $cache = self::cache();
-        if (!file_exists($cache)) {
-            return $template;
+        if (!file_exists($cache))
+        {
+            throw new \Exception('Bladerunner: Cache folder does not exist.');
         }
 
         $search = [$views, '/', '.blade', '.php'];


### PR DESCRIPTION
Loading `template.php` instead of `template.blade.php` if the cache folder is missing is kind of confusing. ("why won't the template load goddamit?"). There's a notice in the admin dash but I don't think we should fail silently here, better let the user know what's going on than give him the wrong templates?
