### PR TITLE
Added a way to pass data to a view

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -15,6 +15,16 @@ class Template
     protected $path;
 
     /**
+     * Stores passed data.
+     *
+     * To pass data use the below example (make sure to run before "template_include" filter):
+     * \Bladerunner\Template::$data['variableName'] = $value;
+     *
+     * @var array
+     */
+    public static $data = array();
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -85,7 +95,7 @@ class Template
             $content .= "   View file '$view_file', compiled at " . date('Y-m-d H:i:s') . "\n";
             $content .= "*/\n";
             $content .= "\$blade = new \Bladerunner\Blade('$views', '$cache');\n";
-            $content .= "echo \$blade->view()->make('$view_file')->render();\n";
+            $content .= "echo \$blade->view()->make('$view_file', json_decode('" . json_encode(self::$data) . "', true))->render();\n";
             file_put_contents($this->path, $content);
         }
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -87,7 +87,7 @@ class Template
 
         $this->path = $cache . '/' . $view_file . '.php';
 
-        if (!file_exists($this->path)) {
+        if (!file_exists($this->path) || !empty(self::$data)) {
             $content = "";
             $content .= "<?php\n";
             $content .= "/*\n";


### PR DESCRIPTION
A simple way to pass data to a view before it's loaded.

Run the below code (and change variableName and $value) before the template_include filter (or in the template_include filter with higher priority than 999) to pass data to the soon to be loaded view.

```
\Bladerunner\Template::$data['variableName'] = $value;
```

Inside your view file you will be able to access the passed data like so:

```
{{ $variableName }}
```
