### PR TITLE
Load searchform.blade.php (if existing) on get_search_form()

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -31,6 +31,7 @@ class Template
     {
         add_filter('template_include', [$this, 'path'], 999);
         add_action('template_redirect', [$this, 'init']);
+        add_filter('get_search_form', [$this, 'getSearchForm'], 999);
     }
 
     /**
@@ -100,6 +101,27 @@ class Template
         }
 
         return $this->path;
+    }
+
+    /**
+     * Get Blade tempalte for search form when using get_search_form()
+     *
+     * @param  string $searchform Default search form markup
+     *
+     * @return bool               Always returns false (to prevent any other output than the include)
+     */
+    public function getSearchForm($searchform)
+    {
+        if (!file_exists(get_template_directory() . '/searchform.blade.php')) {
+            return $searchform;
+        }
+
+        $bladerunner = new self();
+        $templatePath = $bladerunner->path('searchform.blade.php');
+        include $templatePath;
+        unset($bladerunner);
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Leverage the filter "get_search_form" to load searchform.blade.php if existing when calling WP core function `get_search_form()`.

I had to create a new instance of `self()` to the method call to `$this->path('searchform.blade.php');` sinde the `$this->path` will already be set and therefore create "double object instance".

An option would be to put the code inside the Init class instead and create a new instance of the Template class from there.
