### PR TITLE
Add option to use a filter to set path where blade templates are stored

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,10 @@ If you don't want Bladerunner to check for permissions form cache folder then se
 ```php
 add_filter('bladerunner/cache/permission', '__return_null');
 ```
+If you wan't to customize the base path where you have your views stored, use:
+```php
+add_filter('bladerunner/template/bladepath', function ($path) { return $path . '/views'; });
+```
 
 #### Custom extensions
 If you are comfortable with regular expressions and want to add your own extensions to your templates use the filter ``bladerunner/extend``.

--- a/src/Globals.php
+++ b/src/Globals.php
@@ -12,7 +12,8 @@ if (!function_exists('bladerunner')) {
      */
     function bladerunner($view, $data = [])
     {
-        $blade = new \Bladerunner\Blade(get_stylesheet_directory(), \Bladerunner\Cache::path());
+        $bladepath = apply_filters('bladerunner/template/bladepath', get_stylesheet_directory());
+        $blade = new \Bladerunner\Blade($bladepath, \Bladerunner\Cache::path());
         echo $blade->view()->make($view, $data)->render();
     }
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -26,7 +26,7 @@ class Template
 
         $template = apply_filters('bladerunner/template/post', $template);
 
-        $views = get_stylesheet_directory();
+        $views = apply_filters('bladerunner/template/bladepath', get_stylesheet_directory());
 
         $cache = Cache::path();
         if (!file_exists($cache)) {


### PR DESCRIPTION
Usage examle:

`add_filter('bladerunner/template/bladepath', function ($path) {
    return $path . '/views';
});`

and then in your templates:

`@include('layout.header')`

instead of

`@include('views.layout.header')`
