### PR TITLE
New filters and hooks for data and View Factory interaction

### DIFF
--- a/plugin_globals.php
+++ b/plugin_globals.php
@@ -31,9 +31,9 @@ if (!function_exists('bladerunner')) {
         $data = apply_filters("bladerunner/templates/data/$view", $data);
 
         // allow interaction with the View Factory for every rendered view
-        do_action("bladerunner/blade_initialized", $blade , $view );
+        do_action("bladerunner/blade_initialized", $blade, $view);
         // allow interaction with the View Factory for a specific view
-        do_action("bladerunner/blade_initialized/$view", $blade , $view );
+        do_action("bladerunner/blade_initialized/$view", $blade, $view);
 
         $result = $blade->view()->make($view, $data)->render();
 

--- a/plugin_globals.php
+++ b/plugin_globals.php
@@ -30,6 +30,11 @@ if (!function_exists('bladerunner')) {
         // filter for data of a specific view
         $data = apply_filters("bladerunner/templates/data/$view", $data);
 
+        // allow interaction with the View Factory for every rendered view
+        do_action("bladerunner/blade_initialized", $blade , $view );
+        // allow interaction with the View Factory for a specific view
+        do_action("bladerunner/blade_initialized/$view", $blade , $view );
+
         $result = $blade->view()->make($view, $data)->render();
 
         if ($echo) {

--- a/plugin_globals.php
+++ b/plugin_globals.php
@@ -25,6 +25,11 @@ if (!function_exists('bladerunner')) {
         $bladepath = apply_filters('bladerunner/template/bladepath', get_stylesheet_directory());
         $blade = new \Bladerunner\Blade($bladepath, \Bladerunner\Cache::path());
 
+        // filter for all views
+        $data = apply_filters("bladerunner/templates/data", $data);
+        // filter for data of a specific view
+        $data = apply_filters("bladerunner/templates/data/$view", $data);
+
         $result = $blade->view()->make($view, $data)->render();
 
         if ($echo) {

--- a/plugin_globals.php
+++ b/plugin_globals.php
@@ -39,7 +39,7 @@ add_action('save_post', 'Bladerunner\Cache::removeAllViews');
 add_action('admin_init', 'Bladerunner\Init::checkWriteableUpload');
 
 if (apply_filters('bladerunner/templates/handler', false)) {
-    $bladerunner_templates = new Bladerunner\Templates();
+    $bladerunner_templates = new Bladerunner\Template();
     add_filter('template_include', [$bladerunner_templates, 'templateFilter'], 999);
     add_action('template_redirect', [$bladerunner_templates, 'addPageTemplateFilters']);
 }

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -101,17 +101,14 @@ class Blade
      */
     public function registerEngineResolver()
     {
-        $me = $this;
-
-        $this->container->singleton('view.engine.resolver', function ($app) use ($me) {
+        $this->container->singleton('view.engine.resolver', function ($app) {
             $resolver = new EngineResolver();
 
             // Next we will register the various engines with the resolver so that the
             // environment can resolve the engines it needs for various views based
             // on the extension of view files. We call a method for each engines.
-            foreach (['php', 'blade'] as $engine) {
-                $me->{'register'.ucfirst($engine).'Engine'}($resolver);
-            }
+            $this->registerPhpEngine($resolver);
+            $this->registerBladeEngine($resolver);
 
             return $resolver;
         });

--- a/src/Template.php
+++ b/src/Template.php
@@ -30,7 +30,7 @@ class Template
 
         $cache = Cache::path();
         if (!file_exists($cache)) {
-            trigger_error("Bladerunner: Cache folder {$cache} does not exist.", E_WARNING);
+            trigger_error("Bladerunner: Cache folder {$cache} does not exist.", E_USER_WARNING);
 
             return $template;
         }
@@ -46,7 +46,7 @@ class Template
         }
 
         if (!file_exists($template)) {
-            trigger_error("Bladerunner: Missing template file {$template}", E_WARNING);
+            trigger_error("Bladerunner: Missing template file {$template}", E_USER_WARNING);
 
             return $template;
         }


### PR DESCRIPTION
I had two use cases which weren't yet possible and found some minor bugs

1) I want to add data to all views like a ViewComposer would enable.
This was only possible when the Template handler was active.
I've added two filters for the same purpose in the global bladerunner function.

2) I want to call the startPush and stopPush functions from the View Factory to add some scripts without changing the blade files, because they are from another package.
Therefore I added two actions to be able to hook into the initialized Blade instance.