### PR TITLE
Make `bladepath` example work in strict php

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,9 +155,12 @@ add_filter('bladerunner/cache/permission', '__return_null');
 ```
 If you wan't to customize the base paths where you have your views stored, use:
 ```php
-add_filter('bladerunner/template/bladepath', function ($paths) { 
-    $paths[] = PLUGIN_DIR . '/my-fancy-plugin/views';
-    return $path; 
+add_filter('bladerunner/template/bladepath', function ($paths) {
+    if (!is_array($paths)) {
+        $paths = [$paths];
+    }
+    $paths[] = ABSPATH . '../../resources/views';
+    return $paths;
 });
 ```
 If you wan't to customize the controller paths where you have your controllers stored, use:


### PR DESCRIPTION
Issues: 
`bladerunner/template/bladepath` example returned undefined `$path` instead of `$paths`
`bladerunner/template/bladepath` can be called with a string, the example would then choke on `$paths[] =`