### PR TITLE
Disable cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 phpunit.xml
 vendor
+.idea

--- a/bladerunner.php
+++ b/bladerunner.php
@@ -3,7 +3,7 @@
 Plugin Name:        Bladerunner
 Plugin URI:         http://bladerunner.elseif.se
 Description:        Laravel Blade template engine for WordPress
-Version:            1.7.1-dev
+Version:            1.7.2-dev
 Author:             Andreas Ek
 Author URI:         https://www.elseif.se/
 License:            MIT License

--- a/bladerunner.php
+++ b/bladerunner.php
@@ -3,7 +3,7 @@
 Plugin Name:        Bladerunner
 Plugin URI:         http://bladerunner.elseif.se
 Description:        Laravel Blade template engine for WordPress
-Version:            1.7.3
+Version:            1.7.4
 Author:             Andreas Ek
 Author URI:         https://www.elseif.se/
 License:            MIT License

--- a/bladerunner.php
+++ b/bladerunner.php
@@ -3,7 +3,7 @@
 Plugin Name:        Bladerunner
 Plugin URI:         http://bladerunner.elseif.se
 Description:        Laravel Blade template engine for WordPress
-Version:            1.7.4
+Version:            1.7.5
 Author:             Andreas Ek
 Author URI:         https://www.elseif.se/
 License:            MIT License

--- a/bladerunner.php
+++ b/bladerunner.php
@@ -3,7 +3,7 @@
 Plugin Name:        Bladerunner
 Plugin URI:         http://bladerunner.elseif.se
 Description:        Laravel Blade template engine for WordPress
-Version:            1.7.2-dev
+Version:            1.7.3
 Author:             Andreas Ek
 Author URI:         https://www.elseif.se/
 License:            MIT License

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "ekandreas/bladerunner",
     "type": "wordpress-plugin",
+    "version": "1.7.3",
     "description": "WordPress Blade L5 template engine",
     "keywords": ["laravel", "blade", "wordpress"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.3"
+            "dev-master": "1.7.3-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "illuminate/config": "^5.0",
-        "illuminate/view": "^5.0",
-        "symfony/yaml": "^3.0",
-        "brain/hierarchy": "^2.0"
+        "illuminate/config": "^5",
+        "illuminate/view": "^5",
+        "symfony/yaml": "^3",
+        "brain/hierarchy": "^2"
     },
     "require-dev": {
         "frozzare/wp-test-suite": "*"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "ekandreas/bladerunner",
     "type": "wordpress-plugin",
-    "version": "1.7.1-dev",
     "description": "WordPress Blade L5 template engine",
     "keywords": ["laravel", "blade", "wordpress"],
     "license": "MIT",
@@ -12,26 +11,30 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "illuminate/config": "5.*",
-        "illuminate/view": "5.*",
-        "symfony/yaml": "3.*",
-        "brain/hierarchy":"2.*"
+        "php": "^5.6 || ^7.0",
+        "illuminate/config": "^5.0",
+        "illuminate/view": "^5.0",
+        "symfony/yaml": "^3.0",
+        "brain/hierarchy": "^2.0"
     },
-    "autoload": {
-        "psr-4": {
-            "Bladerunner\\Tests\\": "tests/",
-            "Bladerunner\\": "src/"
-        }
-    },
-    "prefer-stable": true,
-    "minimum-stability": "dev",
     "require-dev": {
         "frozzare/wp-test-suite": "*"
     },
+    "autoload": {
+        "psr-4": {
+            "Bladerunner\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Bladerunner\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
-            "dev-develop": "1.7.1-dev"
+            "dev-develop": "1.7-dev"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.2-dev"
+            "dev-master": "1.7.3"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.3-dev"
+            "dev-master": "1.7.4-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.4-dev"
+            "dev-master": "1.7.5-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "ekandreas/bladerunner",
     "type": "wordpress-plugin",
-    "version": "1.7.3",
     "description": "WordPress Blade L5 template engine",
     "keywords": ["laravel", "blade", "wordpress"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "1.7-dev"
+            "dev-master": "1.7.2-dev"
         }
     },
     "minimum-stability": "dev",

--- a/globals/filters.php
+++ b/globals/filters.php
@@ -12,10 +12,13 @@ array_map(function ($type) {
             ];
             $normalizedTemplate = preg_replace(array_keys($transforms), array_values($transforms), $template);
 
-            $controllerPaths = collect([
-                apply_filters('bladerunner/controller/paths', []),
-                get_stylesheet_directory() . '/controllers',
-            ])->unique()->toArray();
+            $paths = apply_filters('bladerunner/controller/paths', []);
+            if (!is_array($paths)) {
+                $paths = [$paths];
+            }
+            $paths[] = get_stylesheet_directory() . '/controllers';
+
+            $controllerPaths = collect($paths)->unique()->toArray();
 
             foreach ($controllerPaths as $path) {
                 if (!is_string($path)) {
@@ -39,8 +42,22 @@ array_map(function ($type) {
         return $result;
     });
 }, [
-    'index', '404', 'archive', 'author', 'category', 'tag', 'taxonomy', 'date', 'home',
-    'frontpage', 'page', 'paged', 'search', 'single', 'singular', 'attachment'
+    'index',
+    '404',
+    'archive',
+    'author',
+    'category',
+    'tag',
+    'taxonomy',
+    'date',
+    'home',
+    'frontpage',
+    'page',
+    'paged',
+    'search',
+    'single',
+    'singular',
+    'attachment'
 ]);
 
 add_filter('template_include', function ($template) {

--- a/globals/filters.php
+++ b/globals/filters.php
@@ -18,7 +18,9 @@ array_map(function ($type) {
             ])->unique()->toArray();
 
             foreach ($controllerPaths as $path) {
-                if(!is_string($path)) continue;
+                if (!is_string($path)) {
+                    continue;
+                }
                 $controllerPath = "{$path}/{$normalizedTemplate}.php";
                 if (file_exists($controllerPath)) {
                     add_filter('bladerunner/controllers/heap', function ($heap) use ($controllerPath) {

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -17,26 +17,9 @@ add_action('after_setup_theme', function () {
         'uri.template' => get_template_directory_uri(),
     ];
 
-    $bladePaths = apply_filters('bladerunner/template/bladepath', $paths['dir.stylesheet']);
-    if (!is_array($bladePaths)) {
-        $bladePaths = [$bladePaths];
-    }
-
-    $bladePaths[] = $paths['dir.stylesheet'] . DIRECTORY_SEPARATOR . 'views';
-    $bladePaths[] = STYLESHEETPATH;
-    $bladePaths[] = TEMPLATEPATH;
-
-    $viewPaths = array_values(collect($bladePaths, preg_replace('%[\/]?(templates)?[\/.]*?$%', '', $bladePaths))
-        ->flatMap(function ($path) {
-            if (strstr($path, '/views')) {
-                return [$path, $path];
-            }
-            return ["{$path}/templates", $path];
-        })->unique()->toArray());
-
     \Bladerunner\Config::repo([
             'view.compiled' => "{$paths['dir.upload']}/.cache",
-            'view.paths' => $viewPaths,
+            'view.paths' => \Bladerunner\Config::viewPaths(),
         ] + $paths);
 
     /**

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -55,7 +55,6 @@ add_action('after_setup_theme', function () {
 
 
     $extensions = apply_filters('bladerunner/extend', []);
-    var_dump($extensions);
     if ($extensions && is_array($extensions)) {
         foreach ($extensions as $extension) {
             if (is_callable($extension)) {

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -61,7 +61,6 @@ add_action('after_setup_theme', function () {
         array_map('unlink',
         glob(\Bladerunner\Config::repo('view.compiled') . '/*'));
     }
-
 });
 
 /**

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -49,11 +49,6 @@ add_action('after_setup_theme', function () {
             }
         }
     }
-
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        array_map('unlink',
-            glob(\Bladerunner\Config::repo('view.compiled') . '/*'));
-    }
 });
 
 /**

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -48,12 +48,6 @@ add_action('after_setup_theme', function () {
         return '<?php (new \Bladerunner\ControllerDebug(get_defined_vars())); ?>';
     });
 
-    if (defined('WP_DEBUG') && WP_DEBUG) {
-        array_map('unlink',
-        glob(\Bladerunner\Config::repo('view.compiled') . '/*'));
-    }
-
-
     $extensions = apply_filters('bladerunner/extend', []);
     if ($extensions && is_array($extensions)) {
         foreach ($extensions as $extension) {
@@ -62,6 +56,12 @@ add_action('after_setup_theme', function () {
             }
         }
     }
+
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+        array_map('unlink',
+        glob(\Bladerunner\Config::repo('view.compiled') . '/*'));
+    }
+
 });
 
 /**

--- a/globals/setup.php
+++ b/globals/setup.php
@@ -18,7 +18,7 @@ add_action('after_setup_theme', function () {
     ];
 
     \Bladerunner\Config::repo([
-            'view.compiled' => "{$paths['dir.upload']}/.cache",
+            'view.compiled' => apply_filters('bladerunner/cache/path', "{$paths['dir.upload']}/.cache"),
             'view.paths' => \Bladerunner\Config::viewPaths(),
         ] + $paths);
 
@@ -27,9 +27,12 @@ add_action('after_setup_theme', function () {
      */
     Bladerunner\Container::current()->singleton('bladerunner.blade', function (ContainerContract $app) {
         $cachePath = Bladerunner\Config::repo('view.compiled');
-        if (!file_exists($cachePath)) {
+
+        $makePath = apply_filters('bladerunner/cache/make', true);
+        if ($makePath && !file_exists($cachePath)) {
             wp_mkdir_p($cachePath);
         }
+
         (new \Bladerunner\BladeProvider($app))->register();
         return new \Bladerunner\Blade($app['view'], $app);
     });

--- a/readme.md
+++ b/readme.md
@@ -23,14 +23,14 @@ Releases to this plugin is listed last in this readme.
 
 ## Hello World
 1. Install the library with composer
-2. Make sure the cache-folder is writeable in uploads, eg ../wp-content/uploads/.cache
+2. Make sure the cache-folder is writeable in uploads, eg `../wp-content/uploads/.cache`
 3. Activate the plugin
 4. Create a view, eg:
 ```twig
 <!-- view file: views/pages/index.blade.php -->
 Hello World Page rendered at {{ date('Y-m-d H:i:s') }}
 ```
-5. In your index.php, add a global call for the view created, eg:
+5. In your `index.php`, add a global call for the view created, eg:
 ```php
 <?php
     bladerunner('views.pages.index')
@@ -39,20 +39,20 @@ Hello World Page rendered at {{ date('Y-m-d H:i:s') }}
 [https://laravel.com/docs/5.2/blade](https://laravel.com/docs/5.2/blade)
 
 ## Cache
-* If WP_DEBUG is set and true then templates always will be rendered and updated.
-* View files (cache) is invalidated at save_post.
-* (It's a really good idea to empty the .cache folder inside "uploads" when develop templates. Eg, create a "del" command inside your gulp-file.)
+* If `WP_DEBUG` is set and true then templates always will be rendered and updated.
+* View files (cache) is invalidated at `save_post`
+* (It's a really good idea to empty the .cache folder inside `uploads` when develop templates. Eg, create a `del` command inside your gulp-file.)
 
 ## Directories
-* Your cached views will always be stored in your wp upload folder, .cache.
+* Your cached views will always be stored in your wp upload folder, `.cache`
 * Your views must be placed within your theme folder.
-* Your views must have .blade.php extension.
+* Your views must have `.blade.php` extension.
 
 ## Template helper
-There is a template helper function named "bladerunner", defined globally to use in standard WordPress templates.
+There is a template helper function named `bladerunner`, defined globally to use in standard WordPress templates.
 
 Example:
-You want to create a 404-template and don't want to use the .blade.php extension to the template file.
+You want to create a 404-template and don't want to use the `.blade.php` extension to the template file.
 
 * Create a 404.php in the theme root.
 * Add the following code to the template:
@@ -60,9 +60,9 @@ You want to create a 404-template and don't want to use the .blade.php extension
 <?php
     bladerunner('views.pages.404');
 ```
-* In the folder "views/pages", create a blade template "404.blade.php".
+* In the folder `views/pages`, create a blade template `404.blade.php`
 
-You can pass any data with the global "bladerunner" function like so,
+You can pass any data with the global `bladerunner` function like so,
 ```php
 <?php
     bladerunner('views.pages.404', ['module'=>$module]);
@@ -88,7 +88,7 @@ Extend the Controller Class, it is recommended that the class name matches the f
 Create methods within the Controller Class:
 * Use public function to expose the returned values to the Blade views/s.
 * Use public static function to use the function within your Blade view/s.
-* Use protected function for internal controller methods as only public methods are exposed to the view. You can run them within __construct.
+* Use protected function for internal controller methods as only public methods are exposed to the view. You can run them within `__construct`
 
 ### Controller example: 
 

--- a/readme.md
+++ b/readme.md
@@ -166,58 +166,7 @@ add_filter('bladerunner/controller/paths', function ($paths) {
 });
 ```
 
-#### Custom extensions
-If you are comfortable with regular expressions and want to add your own extensions to your templates use the filter ``bladerunner/extend``.
-Note! It takes one *array* as parameter and requires two keys; "pattern" and "replace".
-
-```php
-$extensions[] = [
-	'pattern' => '...',
-	'replace' => '...',
-];
-```
-
-Use the filter as possible way to add your own custom extensions.
-
-In this example we want to add ``@mysyntax`` as a custom extension.
-```php
-/*
- * Add custom extension @mysyntax to Bladerunner
- */
-add_filter('bladerunner/extend', function($extensions) {
-    $extensions[] = [
-    	'pattern' => '/(\s*)@mysyntax(\s*)/',
-    	'replace' => '$1<?php echo "MYSYNTAX COMPILED!"; ?>$2',
-    ];
-    return $extensions;
-});
-```
-Then use your new syntax inside a WordPress blade template like so:
-```php
-	@mysyntax
-```
-
 We will soon add more WordPress extenstions to the Bladerunner engine. Please give us your great examples to implement!
-
-#### Template Data Filter
-A simple way to pass data to a given view before it's loaded.
-
-Set the filter ``bladerunner/templates/data/{view}`` before running a template to pass custom data to the template, eg:
-```php
-$data = [
-	'this' => 'that',
-	'other' => 'perhaps',
-];
-add_filter('bladerunner/templates/data/single', $data);
-```
-
-Inside your "single.blade.php" / view file you will be able to access the passed data like so:
-```php
-{{ $data['this'] }}
-{{ $data['other'] }}
-```
-
-Default value for data is an empty array.
 
 ## Links
 * [Bladerunner site with documentation and distro](http://bladerunner.aekab.se)

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,9 @@ add_filter('bladerunner/cache/path', function() {
 
 If you don't want Bladerunner to create the cache folder:
 ```php
-add_filter('bladerunner/cache/make', false);
+add_filter('bladerunner/cache/make', function() {
+    return false;
+});
 ```
 
 If you wan't to customize the base paths where you have your views stored, use:

--- a/readme.md
+++ b/readme.md
@@ -155,9 +155,12 @@ add_filter('bladerunner/cache/permission', '__return_null');
 ```
 If you wan't to customize the base paths where you have your views stored, use:
 ```php
-add_filter('bladerunner/template/bladepath', function ($paths) { 
-    $paths[] = PLUGIN_DIR . '/my-fancy-plugin/views';
-    return $path; 
+add_filter('bladerunner/template/bladepath', function ($paths) {
+    if (!is_array($paths)) {
+        $paths = [$paths];
+    }
+    $paths[] = ABSPATH . '../../resources/views';
+    return $paths;
 });
 ```
 If you wan't to customize the controller paths where you have your controllers stored, use:

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,13 @@ add_filter('bladerunner/cache/make', function() {
 });
 ```
 
+If you don't want Blade to use cached view files:
+```php
+add_filter('bladerunner/cache/disable', function() {
+    return true;
+});
+```
+
 If you wan't to customize the base paths where you have your views stored, use:
 ```php
 add_filter('bladerunner/template/bladepath', function ($paths) {

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ WordPress plugin for Laravel Blade templating.
 To install it to your Composer based WordPress installation:
 
 ```
-composer require ekandreas/bladerunner:*
+composer require ekandreas/bladerunner
 ```
 Activate the plugin inside WordPress and templates with *.blade.php are inspected and active.
 Your theme still needs an index.php due to WordPress basic functionality. When removed the theme is known as broken.

--- a/readme.md
+++ b/readme.md
@@ -143,16 +143,11 @@ add_filter('bladerunner/cache/path', function() {
 });
 ```
 
-Permission settings to cache folder, default 777
+If you don't want Bladerunner to create the cache folder:
 ```php
-add_filter('bladerunner/cache/permission', function() {
-	return 644;
-});
+add_filter('bladerunner/cache/make', false);
 ```
-If you don't want Bladerunner to check for permissions form cache folder then set the return to null, eg:
-```php
-add_filter('bladerunner/cache/permission', '__return_null');
-```
+
 If you wan't to customize the base paths where you have your views stored, use:
 ```php
 add_filter('bladerunner/template/bladepath', function ($paths) { 

--- a/readme.md
+++ b/readme.md
@@ -243,26 +243,3 @@ Using *Testrunner* (required-dev package) and Docker the test should be exexuted
 ```bash
 vendor/bin/dep testrunner
 ```
-
-## Releases
-
-### 1.7
-Controller concept included, read more about it at [https://bladerunner.elseif.se/controllers](https://bladerunner.elseif.se/controllers)
-
-### Release 1.6.1 and 1.6.2
-Just to update Laravel Blade engine upgrades
-
-### Release 1.6
-Laravel 5.4 with Components and Slots!
-This is a completely rewrite, perhaps v2? Extracted from Roots Sage.
-Some breaking changes:
-* Laravel Config and View v5.4, these are in dev mode right now.
-* Global function view over old global bladerunner for no echo as default.
-* No template filters. You need to use "view" or "bladerunner" global functions in your ordinary WordPress templates.
-* No WP admin pages, this is a dev tool :-)
-
-### Release 1.5
-Now only supports PHP5.6 and greater.
-Laravel 5.3 is used as blade base.
-
-

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ekandreas
 Tags: Blade,templates,development,laravel
 Requires at least: 4.4
 Tested up to: 4.8.1
-Stable tag: 1.7.2-dev
+Stable tag: 1.7.3
 License: MIT
 
 WordPress plugin for Blade L5 templating

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ekandreas
 Tags: Blade,templates,development,laravel
 Requires at least: 4.4
 Tested up to: 4.8.1
-Stable tag: 1.7.1-dev
+Stable tag: 1.7.2-dev
 License: MIT
 
 WordPress plugin for Blade L5 templating

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ekandreas
 Tags: Blade,templates,development,laravel
 Requires at least: 4.4
 Tested up to: 4.8.1
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 License: MIT
 
 WordPress plugin for Blade L5 templating

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ekandreas
 Tags: Blade,templates,development,laravel
 Requires at least: 4.4
 Tested up to: 4.8.1
-Stable tag: 1.7.3
+Stable tag: 1.7.4
 License: MIT
 
 WordPress plugin for Blade L5 templating

--- a/src/BladeCompiler.php
+++ b/src/BladeCompiler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bladerunner;
+
+class BladeCompiler extends \Illuminate\View\Compilers\BladeCompiler
+{
+    public function isExpired($path)
+    {
+        $forceCompile = apply_filters('bladerunner\cache\disable', WP_DEBUG, $path);
+
+        if ($forceCompile) {
+            return true;
+        }
+
+        return parent::isExpired($path);
+    }
+}

--- a/src/BladeProvider.php
+++ b/src/BladeProvider.php
@@ -5,6 +5,8 @@ use Illuminate\Container\Container as BaseContainer;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\ViewServiceProvider;
 
 /**
@@ -86,5 +88,27 @@ class BladeProvider extends ViewServiceProvider
             return $finder;
         }, true);
         return $this;
+    }
+
+    /**
+     * Register the Blade engine implementation.
+     *
+     * @param  \Illuminate\View\Engines\EngineResolver  $resolver
+     * @return void
+     */
+    public function registerBladeEngine($resolver)
+    {
+        // The Compiler engine requires an instance of the CompilerInterface, which in
+        // this case will be the Blade compiler, so we'll first create the compiler
+        // instance to pass into the engine so it can compile the views properly.
+        $this->app->singleton('blade.compiler', function () {
+            return new BladeCompiler(
+                $this->app['files'], $this->app['config']['view.compiled']
+            );
+        });
+
+        $resolver->register('blade', function () {
+            return new CompilerEngine($this->app['blade.compiler']);
+        });
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,4 +24,41 @@ class Config
         }
         return Container::current('config')->get($key, $default);
     }
+
+    /**
+     * Gets all valid paths to views and templates through the installation
+     * @return array
+     */
+    public static function viewPaths()
+    {
+        $bladePaths = apply_filters('bladerunner/template/bladepath', get_stylesheet_directory());
+        if (!is_array($bladePaths)) {
+            $bladePaths = [$bladePaths];
+        }
+
+        $stylesheetPath = get_stylesheet_directory();
+        $templatePath = get_template_directory();
+
+        $bladePaths[] = $stylesheetPath . DIRECTORY_SEPARATOR . 'views';
+        $bladePaths[] = $stylesheetPath . DIRECTORY_SEPARATOR . 'views';
+
+        $themePaths = [
+            $stylesheetPath,
+            $stylesheetPath . DIRECTORY_SEPARATOR . 'templates',
+            $templatePath,
+            $templatePath . DIRECTORY_SEPARATOR . 'templates',
+            STYLESHEETPATH, // compability
+            STYLESHEETPATH . DIRECTORY_SEPARATOR . 'templates',
+            TEMPLATEPATH, // compability
+            TEMPLATEPATH . DIRECTORY_SEPARATOR . 'templates',
+        ];
+
+        $bladePaths = array_merge($bladePaths, $themePaths);
+
+        $viewPaths = array_values(
+            collect($bladePaths, preg_replace('%[\/]?(templates)?[\/.]*?$%', '', $bladePaths))->unique()->toArray()
+        );
+
+        return $viewPaths;
+    }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -10,13 +10,13 @@ class Container extends BaseContainer
      *
      * @param string $abstract
      * @param array $parameters
-     * @param ContainerContract $container
-     * @return ContainerContract|mixed
+     * @param Container $container
+     * @return Container|mixed
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
-    public static function current($abstract = null, $parameters = [], ContainerContract $container = null)
+    public static function current($abstract = null, $parameters = [], Container $container = null)
     {
-        $container = $container ?: \Bladerunner\Container::getInstance();
+        $container = $container ?: Container::getInstance();
         if (!$abstract) {
             return $container;
         }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -118,6 +118,10 @@ class Controller
 
     public function __getView()
     {
+        if (isset($this->template) && $this->template) {
+            return $this->template;
+        }
+
         if (isset($this->view) && $this->view) {
             return $this->view;
         }

--- a/src/ControllerDebug.php
+++ b/src/ControllerDebug.php
@@ -2,6 +2,8 @@
 
 namespace Bladerunner;
 
+use Brain\Hierarchy\Hierarchy;
+
 class ControllerDebug
 {
     protected $data;
@@ -55,7 +57,6 @@ class ControllerDebug
      */
     public function controller()
     {
-        // unset($this->data['post']);
         echo "<pre><strong>Controller:</strong><ul>";
         foreach ($this->data as $name => $item) {
             $item = (is_array($item) ? gettype($item) . '[' . count($item) . ']' : gettype($item));
@@ -72,10 +73,10 @@ class ControllerDebug
     public function templates()
     {
         global $wp_query;
-        $templates = (new \Brain\Hierarchy\Hierarchy())->getTemplates($wp_query);
+        $templates = (new Hierarchy())->getTemplates($wp_query);
         echo '<pre><strong>Controller Template Hierarchy (first has highest prio):</strong><ul>';
         foreach ($templates as $template) {
-            if (strpos($template, '.blade.php') || $template === 'index.php') {
+            if ($template === 'index.php') {
                 continue;
             }
             if ($template === 'index') {


### PR DESCRIPTION
The current way to disable cache is only possible by setting WP_DEBUG to true.
For a project I currently need to disable cache on the production site.
So I've added a filter to disable cache.
And while working on it it seemed prettier to only recompile the necessary files instead of removing all cached files on every request.